### PR TITLE
Add simple realtime chatroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# Secure-Chat
+# Secure Chatroom
+
+This project provides a simple realtime chatroom where everyone uses a shared password. It runs both backend and frontend on the same server using Node.js and Socket.IO.
+
+## Features
+
+- Login with any username and a shared password (`secret` by default).
+- Realtime chatting with message replies.
+- Messages stored in a small JSON database.
+- Timestamps displayed in Iran timezone.
+
+## Quick Setup on Ubuntu 20.04+
+
+```bash
+# install node if you don't have it
+curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# clone and install
+git clone <repo-url> secure-chat
+cd secure-chat
+npm install
+
+# optional: open firewall for port 8000
+sudo ufw allow 8000/tcp
+
+# start the chatroom
+npm start
+```
+
+Then open `http://your-server-ip:8000` in your browser.
+
+## Usage
+
+1. Visit the server in a browser.
+2. Enter any username and the shared password `secret`.
+3. Start chatting!
+
+Messages include the sender name, timestamp (Iran time), message text and a reply option.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "secure-chat",
+  "version": "1.0.0",
+  "description": "Simple realtime chatroom",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.6.1",
+    "lowdb": "^6.0.1",
+    "dayjs": "^1.11.10",
+    "dayjs-plugin-timezone": "^1.0.1",
+    "dayjs-plugin-utc": "^1.0.2"
+  }
+}

--- a/public/chat.html
+++ b/public/chat.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Chat Room</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 20px auto; }
+    #messages { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: scroll; }
+    .msg { margin: 5px 0; }
+    .meta { color: #555; font-size: 0.8em; }
+    .reply { cursor: pointer; color: blue; text-decoration: underline; font-size: 0.8em; }
+  </style>
+</head>
+<body>
+<h2>Chat Room</h2>
+<div id="messages"></div>
+<input id="replyTo" type="hidden" />
+<input id="input" autocomplete="off" placeholder="Type a message" style="width:80%"/>
+<button onclick="send()">Send</button>
+<script src="/socket.io/socket.io.js"></script>
+<script>
+const socket = io();
+const user = sessionStorage.getItem('username');
+if(!user) location = '/';
+
+socket.emit('join', user);
+
+const msgs = document.getElementById('messages');
+const input = document.getElementById('input');
+const replyToInput = document.getElementById('replyTo');
+
+socket.on('init', ms => { ms.forEach(addMessage); scroll(); });
+
+socket.on('message', msg => { addMessage(msg); scroll(); });
+
+function addMessage(msg) {
+  const div = document.createElement('div');
+  div.className = 'msg';
+  const meta = document.createElement('div');
+  meta.className = 'meta';
+  meta.textContent = msg.user + ' @ ' + msg.time;
+  const text = document.createElement('div');
+  text.textContent = msg.text;
+  div.appendChild(meta);
+  if(msg.replyTo) {
+    const reply = document.createElement('div');
+    reply.style.borderLeft = '2px solid #ccc';
+    reply.style.marginLeft = '10px';
+    reply.style.paddingLeft = '10px';
+    reply.className = 'replyMsg';
+    const r = document.getElementById('msg-' + msg.replyTo);
+    reply.textContent = r ? r.querySelector('.meta').textContent + ': ' + r.querySelector('.text').textContent : '[original message]';
+    div.appendChild(reply);
+  }
+  text.className = 'text';
+  div.appendChild(text);
+  const replyOpt = document.createElement('div');
+  replyOpt.className = 'reply';
+  replyOpt.textContent = 'reply';
+  replyOpt.onclick = () => { replyToInput.value = msg.id; input.focus(); };
+  div.appendChild(replyOpt);
+  div.id = 'msg-' + msg.id;
+  msgs.appendChild(div);
+}
+
+function send() {
+  if(!input.value) return;
+  socket.emit('message', { text: input.value, replyTo: replyToInput.value || null });
+  input.value = '';
+  replyToInput.value = '';
+}
+
+function scroll() { msgs.scrollTop = msgs.scrollHeight; }
+</script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Login</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 400px; margin: 100px auto; text-align: center; }
+    input { padding: 8px; margin: 5px; }
+  </style>
+</head>
+<body>
+  <h2>Login</h2>
+  <input id="username" placeholder="Username" /><br>
+  <input id="password" type="password" placeholder="Password" /><br>
+  <button onclick="login()">Enter Chat</button>
+  <p id="error" style="color:red"></p>
+<script>
+const PASSWORD = 'secret';
+function login() {
+  const user = document.getElementById('username').value.trim();
+  const pass = document.getElementById('password').value;
+  if(!user || pass !== PASSWORD) { document.getElementById('error').innerText = 'Invalid credentials'; return; }
+  sessionStorage.setItem('username', user);
+  window.location = '/chat.html';
+}
+</script>
+</body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const { Low, JSONFile } = require('lowdb');
+const dayjs = require('dayjs');
+const utc = require('dayjs-plugin-utc');
+const timezone = require('dayjs-plugin-timezone');
+
+// Setup dayjs for Iran timezone
+dayjs.extend(utc);
+dayjs.extend(timezone);
+const TZ = 'Asia/Tehran';
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+
+// Lowdb setup
+const adapter = new JSONFile('db.json');
+const db = new Low(adapter, { messages: [] });
+
+async function initDb() {
+  await db.read();
+  db.data = db.data || { messages: [] };
+  await db.write();
+}
+
+initDb();
+
+app.use(express.static('public'));
+
+io.on('connection', socket => {
+  socket.on('join', async username => {
+    socket.username = username;
+    // send existing messages
+    await db.read();
+    socket.emit('init', db.data.messages);
+  });
+
+  socket.on('message', async msg => {
+    const message = {
+      id: Date.now(),
+      user: socket.username,
+      text: msg.text,
+      replyTo: msg.replyTo || null,
+      time: dayjs().tz(TZ).format('YYYY-MM-DD HH:mm:ss')
+    };
+    await db.read();
+    db.data.messages.push(message);
+    await db.write();
+    io.emit('message', message);
+  });
+});
+
+const PORT = 8000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- build a realtime chatroom with Express and Socket.IO
- add login page with fixed password and chat page UI
- create JSON file-based message database
- document setup and usage instructions

## Testing
- `npm install --silent` *(fails: no output)*
- `npm start >/tmp/server.log 2>&1 &` *(fails: modules missing because install failed)*


------
https://chatgpt.com/codex/tasks/task_e_6850734f70f48333a645ba0fe5fbf53e